### PR TITLE
Turn off Voronoi based interaction - fixes #5

### DIFF
--- a/ec2price/templates/main.html
+++ b/ec2price/templates/main.html
@@ -91,7 +91,9 @@ function prices() {
 $(function() {
   nv.addGraph(function() {  
     var chart = nv.models.scatterChart();
-
+    
+    chart.useVoronoi(false);
+    
     chart.xAxis
         .axisLabel('Date')
         .tickFormat(function (d) {


### PR DESCRIPTION
While nice from a UX point of view, it's a CPU & memory hog for large numbers. With it off, hover still works, but only when you're directly over the point, rather than in the neighborhood (Voronoi region).
